### PR TITLE
Add Pillow to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ git-python
 tesserocr
 click
 tqdm
+Pillow


### PR DESCRIPTION
It is required because gtmake.py imports from PIL.

Signed-off-by: Stefan Weil <sw@weilnetz.de>